### PR TITLE
fixed price per week over $1000 not parsing correctly

### DIFF
--- a/script.js
+++ b/script.js
@@ -188,5 +188,8 @@ function parsePriceDomain(price) {
 function parsePriceTradeMe(price) {
   price = price.split(" ")[0];
   price = price.replace("$", "");
+  if (price.includes(",")) {
+    price = price.replace(",", "");
+  }
   return price;
 }


### PR DESCRIPTION
Price per week per person was showing up as $0 if the original price was over $1,000. Removing commas when parsing the price fixed the issue